### PR TITLE
Fix csharp implementation

### DIFF
--- a/encryption-lib/CS-Encryption-Lib/encyption-lib-core/Services/OAuth2JwksService.cs
+++ b/encryption-lib/CS-Encryption-Lib/encyption-lib-core/Services/OAuth2JwksService.cs
@@ -104,8 +104,6 @@ namespace com.tmobile.oss.security.taap.jwe
                 string popToken = CreatePopToken(authorization, _oAuthUri.PathAndQuery, HttpMethod.Post);
                 httpRequestMessage.Headers.Add("X-Authorization", popToken);
             }
-                httpRequestMessage.Headers.Add("X-Authorization", popToken);
-            }
 
             var httpResponseMessage = await _jwksServiceHttpClient.SendAsync(httpRequestMessage);
             httpResponseMessage.EnsureSuccessStatusCode();
@@ -159,6 +157,26 @@ namespace com.tmobile.oss.security.taap.jwe
             else if(method == HttpMethod.Get)
             {
                 dictionary.Add(PopEhtsKeyEnum.HttpMethod.GetDescription(), PopEhtsKeyEnum.Get.GetDescription());
+            }
+            else if (method == HttpMethod.Put)
+            {
+                dictionary.Add(PopEhtsKeyEnum.HttpMethod.GetDescription(), PopEhtsKeyEnum.Put.GetDescription());
+            }
+            else if (method == HttpMethod.Patch)
+            {
+                dictionary.Add(PopEhtsKeyEnum.HttpMethod.GetDescription(), PopEhtsKeyEnum.Patch.GetDescription());
+            }
+            else if (method == HttpMethod.Head)
+            {
+                dictionary.Add(PopEhtsKeyEnum.HttpMethod.GetDescription(), PopEhtsKeyEnum.Head.GetDescription());
+            }
+            else if (method == HttpMethod.Options)
+            {
+                dictionary.Add(PopEhtsKeyEnum.HttpMethod.GetDescription(), PopEhtsKeyEnum.Options.GetDescription());
+            }
+            else if (method == HttpMethod.Trace)
+            {
+                dictionary.Add(PopEhtsKeyEnum.HttpMethod.GetDescription(), PopEhtsKeyEnum.Trace.GetDescription());
             }
 
             dictionary.Add(PopEhtsKeyEnum.Uri.GetDescription(), uri);


### PR DESCRIPTION
### Description of the Change

The PoP Token builder should take in the HTTP Method and URI to properly generate a PoP token.  Additionally, there were dictionary entries in the CreatePopToken method that were unnecessary and causing hash mismatch issues.  The GetJsonWebKeyListAsync method did not contain any logic to utilize the PoP token builder if instantiated.

### Benefits

The C# library should work now for SaaS clients required to utilize a PoP token for Apigee API access.

### Possible Drawbacks

None.

### Applicable Issues

None formally logged.  The underlying issue was raised via email and discovered during a live debug session with MT.
